### PR TITLE
Add integration context

### DIFF
--- a/client/index.jsx
+++ b/client/index.jsx
@@ -1,4 +1,5 @@
 import React, { Suspense } from 'react';
+import PropTypes from 'prop-types';
 // import { render } from 'react-dom';
 // import { hot } from 'react-hot-loader/root';
 import { Provider } from 'react-redux';
@@ -9,6 +10,7 @@ import routes from './routes';
 import ThemeProvider from './modules/App/components/ThemeProvider';
 import Loader from './modules/App/components/loader';
 import './i18n';
+import { IntegrationProvider } from './integration-context';
 
 require('./styles/main.scss');
 
@@ -20,19 +22,34 @@ const initialState = window.__INITIAL_STATE__;
 
 const store = configureStore(initialState);
 
-const App = () => (
-  <Provider store={store}>
-    <ThemeProvider>
-      <Router history={history} routes={routes(store)} />
-    </ThemeProvider>
-  </Provider>
+const App = ({ integration }) => (
+  <IntegrationProvider value={integration}>
+    <Provider store={store}>
+      <ThemeProvider>
+        <Router history={history} routes={routes(store)} />
+      </ThemeProvider>
+    </Provider>
+  </IntegrationProvider>
 );
 
-export const P5Editor = () => (
+// eslint-disable-next-line import/prefer-default-export
+export const P5Editor = ({ integration }) => (
   <Suspense fallback={<Loader />}>
-    <App />
+    <App integration={integration} />
   </Suspense>
 );
+
+App.propTypes = {
+  integration: PropTypes.shape({
+    learningComponent: PropTypes.element
+  }).isRequired
+};
+
+P5Editor.propTypes = {
+  integration: PropTypes.shape({
+    learningComponent: PropTypes.element
+  }).isRequired
+};
 
 // const HotApp = hot(App);
 

--- a/client/integration-context.jsx
+++ b/client/integration-context.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const IntegrationContext = React.createContext();
+
+export const IntegrationProvider = ({ value, children }) => (
+  <IntegrationContext.Provider value={value}>
+    {children}
+  </IntegrationContext.Provider>
+);
+
+IntegrationProvider.propTypes = {
+  value: PropTypes.shape({
+    learningComponent: PropTypes.element
+  }).isRequired,
+  children: PropTypes.element
+};
+
+IntegrationProvider.defaultProps = {
+  children: undefined
+};

--- a/client/modules/IDE/components/Toolbar.jsx
+++ b/client/modules/IDE/components/Toolbar.jsx
@@ -7,6 +7,7 @@ import { withTranslation } from 'react-i18next';
 import * as IDEActions from '../actions/ide';
 import * as preferenceActions from '../actions/preferences';
 import * as projectActions from '../actions/project';
+import { IntegrationContext } from '../../../integration-context';
 
 import PlayIcon from '../../../images/play.svg';
 import StopIcon from '../../../images/stop.svg';
@@ -83,108 +84,118 @@ class Toolbar extends React.Component {
     const canEditProjectName = this.canEditProjectName();
 
     return (
-      <div className="toolbar">
-        <button
-          className="toolbar__play-sketch-button"
-          onClick={() => {
-            this.props.syncFileContent();
-            this.props.startAccessibleSketch();
-            this.props.setTextOutput(true);
-            this.props.setGridOutput(true);
-          }}
-          aria-label={this.props.t('Toolbar.PlaySketchARIA')}
-          disabled={this.props.infiniteLoop}
-        >
-          <PlayIcon focusable="false" aria-hidden="true" />
-        </button>
-        <button
-          className={playButtonClass}
-          onClick={() => {
-            this.props.syncFileContent();
-            this.props.startSketch();
-          }}
-          aria-label={this.props.t('Toolbar.PlayOnlyVisualSketchARIA')}
-          disabled={this.props.infiniteLoop}
-        >
-          <PlayIcon focusable="false" aria-hidden="true" />
-        </button>
-        <button
-          className={stopButtonClass}
-          onClick={this.props.stopSketch}
-          aria-label={this.props.t('Toolbar.StopSketchARIA')}
-        >
-          <StopIcon focusable="false" aria-hidden="true" />
-        </button>
-        <div className="toolbar__autorefresh">
-          <input
-            id="autorefresh"
-            className="checkbox__autorefresh"
-            type="checkbox"
-            checked={this.props.autorefresh}
-            onChange={(event) => {
-              this.props.setAutorefresh(event.target.checked);
-            }}
-          />
-          <label htmlFor="autorefresh" className="toolbar__autorefresh-label">
-            {this.props.t('Toolbar.Auto-refresh')}
-          </label>
-        </div>
-        <div className={nameContainerClass}>
-          <button
-            className="toolbar__project-name"
-            onClick={() => {
-              if (canEditProjectName) {
-                this.props.showEditProjectName();
-                setTimeout(() => this.projectNameInput.focus(), 0);
-              }
-            }}
-            disabled={!canEditProjectName}
-            aria-label={this.props.t('Toolbar.EditSketchARIA')}
-          >
-            <span>{this.props.project.name}</span>
-            {canEditProjectName && (
-              <EditProjectNameIcon
-                className="toolbar__edit-name-button"
-                focusable="false"
-                aria-hidden="true"
+      <IntegrationContext.Consumer>
+        {(value) => (
+          <div className="toolbar">
+            <button
+              className="toolbar__play-sketch-button"
+              onClick={() => {
+                this.props.syncFileContent();
+                this.props.startAccessibleSketch();
+                this.props.setTextOutput(true);
+                this.props.setGridOutput(true);
+              }}
+              aria-label={this.props.t('Toolbar.PlaySketchARIA')}
+              disabled={this.props.infiniteLoop}
+            >
+              <PlayIcon focusable="false" aria-hidden="true" />
+            </button>
+            <button
+              className={playButtonClass}
+              onClick={() => {
+                this.props.syncFileContent();
+                this.props.startSketch();
+              }}
+              aria-label={this.props.t('Toolbar.PlayOnlyVisualSketchARIA')}
+              disabled={this.props.infiniteLoop}
+            >
+              <PlayIcon focusable="false" aria-hidden="true" />
+            </button>
+            <button
+              className={stopButtonClass}
+              onClick={this.props.stopSketch}
+              aria-label={this.props.t('Toolbar.StopSketchARIA')}
+            >
+              <StopIcon focusable="false" aria-hidden="true" />
+            </button>
+            <div className="toolbar__autorefresh">
+              <input
+                id="autorefresh"
+                className="checkbox__autorefresh"
+                type="checkbox"
+                checked={this.props.autorefresh}
+                onChange={(event) => {
+                  this.props.setAutorefresh(event.target.checked);
+                }}
               />
-            )}
-          </button>
-          <input
-            type="text"
-            maxLength="128"
-            className="toolbar__project-name-input"
-            aria-label={this.props.t('Toolbar.NewSketchNameARIA')}
-            value={this.state.projectNameInputValue}
-            onChange={this.handleProjectNameChange}
-            ref={(element) => {
-              this.projectNameInput = element;
-            }}
-            onBlur={this.handleProjectNameSave}
-            onKeyPress={this.handleKeyPress}
-          />
-          {(() => {
-            if (this.props.owner) {
-              return (
-                <p className="toolbar__project-owner">
-                  {this.props.t('Toolbar.By')}{' '}
-                  <Link to={`/${this.props.owner.username}/sketches`}>
-                    {this.props.owner.username}
-                  </Link>
-                </p>
-              );
-            }
-            return null;
-          })()}
-        </div>
-        <button
-          className={preferencesButtonClass}
-          onClick={this.props.openPreferences}
-          aria-label={this.props.t('Toolbar.OpenPreferencesARIA')}
-        >
-          <PreferencesIcon focusable="false" aria-hidden="true" />
-        </button>
-      </div>
+              <label
+                htmlFor="autorefresh"
+                className="toolbar__autorefresh-label"
+              >
+                {this.props.t('Toolbar.Auto-refresh')}
+              </label>
+            </div>
+            <div className={nameContainerClass}>
+              <button
+                className="toolbar__project-name"
+                onClick={() => {
+                  if (canEditProjectName) {
+                    this.props.showEditProjectName();
+                    setTimeout(() => this.projectNameInput.focus(), 0);
+                  }
+                }}
+                disabled={!canEditProjectName}
+                aria-label={this.props.t('Toolbar.EditSketchARIA')}
+              >
+                <span>{this.props.project.name}</span>
+                {canEditProjectName && (
+                  <EditProjectNameIcon
+                    className="toolbar__edit-name-button"
+                    focusable="false"
+                    aria-hidden="true"
+                  />
+                )}
+              </button>
+              <input
+                type="text"
+                maxLength="128"
+                className="toolbar__project-name-input"
+                aria-label={this.props.t('Toolbar.NewSketchNameARIA')}
+                value={this.state.projectNameInputValue}
+                onChange={this.handleProjectNameChange}
+                ref={(element) => {
+                  this.projectNameInput = element;
+                }}
+                onBlur={this.handleProjectNameSave}
+                onKeyPress={this.handleKeyPress}
+              />
+              {(() => {
+                if (this.props.owner) {
+                  return (
+                    <p className="toolbar__project-owner">
+                      {this.props.t('Toolbar.By')}{' '}
+                      <Link to={`/${this.props.owner.username}/sketches`}>
+                        {this.props.owner.username}
+                      </Link>
+                    </p>
+                  );
+                }
+                return null;
+              })()}
+            </div>
+            <div className="toolbar__learning-component">
+              {value && value.learningComponent}
+            </div>
+            <button
+              className={preferencesButtonClass}
+              onClick={this.props.openPreferences}
+              aria-label={this.props.t('Toolbar.OpenPreferencesARIA')}
+            >
+              <PreferencesIcon focusable="false" aria-hidden="true" />
+            </button>
+          </div>
+        )}
+      </IntegrationContext.Consumer>
     );
   }
 }

--- a/client/modules/Preview/previewIndex.jsx
+++ b/client/modules/Preview/previewIndex.jsx
@@ -72,6 +72,7 @@ const App = () => {
   );
 };
 
+// eslint-disable-next-line
 export const P5Preview = () => (
   <div>
     <App />

--- a/client/styles/components/_toolbar.scss
+++ b/client/styles/components/_toolbar.scss
@@ -57,6 +57,10 @@
 	}
 }
 
+.toolbar__learning-component {
+	margin-left: auto;
+}
+
 .toolbar__preferences-button {
 	@include themify() {
 		@extend %toolbar-button;
@@ -68,7 +72,6 @@
 			@extend %toolbar-button--selected;
 		}
 	}
-	margin-left: auto;
 	& span {
 		padding-left: #{1 / $base-font-size}rem;
 		display: flex;


### PR DESCRIPTION
Introduced integration prop to P5Editor and App components.

Changes
- Implemented IntegrationContext and used it to make integration props available in the nested components
- Added .toolbar__learning-component css class and changed existing .toolbar__preferences-button styles to properly place the passed component